### PR TITLE
Get working on recent rakudo

### DIFF
--- a/lib/SSL/Digest.pm
+++ b/lib/SSL/Digest.pm
@@ -28,7 +28,7 @@ sub splitint(int $i) {
 }
 
 sub CArray2Buf($A, Int $length) returns Buf {
-    Buf.new: map &splitint, $A[^$length];
+    Buf.new: $A[^$length].flatmap({ splitint(my int $ = $_) });
 }
 
 sub Buf2Args($buf) {


### PR DESCRIPTION
With this patch all tests pass.

Now have to do `my int $ = $_` when passing the value to &splitint as rakudo doesn't seem to like having values from CArrays passed directly to subs, complaining that it "Cannot auto-decontainerize argument".

Calling &splitint with map now returns a multidimensional Seq which Buf.new won't accept ("This type cannot unbox to a native integer"), so changed to flatmap.