### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,5 +1,6 @@
 {
     "name" : "SSL",
+    "license" : "Artistic-2.0",
     "version" : "0.2.0",
     "description" : "Perl6 interface to a OpenSSL (so far only digests though)",
     "author" : "Lucien Grondin <grondilu@yahoo.fr>",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license