### PR TITLE
Fix tests for openssl version differences

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -11,22 +11,32 @@ sub openssl($dgst, Buf $bytes = $random-bytes) {
 
     qqx{
 	perl -e 'print pack q/H*/, q/$hex/' |
-	openssl dgst -$dgst -binary |
+	openssl dgst -$dgst -binary 2>/dev/null |
 	perl -e 'print unpack "H*", join "", <>;'
     }
 }
 
+sub test-digest(Buf $digest, Str $type, Str $desc ) {
+    my $expected = openssl($type);
+    if $expected {
+        is $digest.unpack('H*'), $expected, $desc;
+    }
+    else {
+        skip "unsupported digest type '$type'", 1 
+    }
+}
+
 my $str = [~] map &chr, $random-bytes.list;
-is md4($str).unpack('H*'), openssl('md4'), 'MD4';
-is md5($str).unpack('H*'), openssl('md5'), 'MD5';
-is sha0($str).unpack('H*'), openssl('sha'), 'SHA-0';
-is sha1($str).unpack('H*'), openssl('sha1'), 'SHA-1';
-is sha224($str).unpack('H*'), openssl('sha224'), 'SHA-224';
-is sha256($str).unpack('H*'), openssl('sha256'), 'SHA-256';
-is sha384($str).unpack('H*'), openssl('sha384'), 'SHA-384';
-is sha512($str).unpack('H*'), openssl('sha512'), 'SHA-512';
-is rmd160($str).unpack('H*'), openssl('rmd160'), 'RIPEMD-160';
-is whirlpool($str).unpack('H*'), openssl('whirlpool'), 'WHIRLPOOL';
+test-digest md4($str),'md4', 'MD4';
+test-digest md5($str), 'md5', 'MD5';
+test-digest sha0($str), 'sha', 'SHA-0';
+test-digest sha1($str), 'sha1', 'SHA-1';
+test-digest sha224($str), 'sha224', 'SHA-224';
+test-digest sha256($str), 'sha256', 'SHA-256';
+test-digest sha384($str), 'sha384', 'SHA-384';
+test-digest sha512($str), 'sha512', 'SHA-512';
+test-digest rmd160($str), 'rmd160', 'RIPEMD-160';
+test-digest whirlpool($str), 'whirlpool', 'WHIRLPOOL';
 
 # md2 no longer seems to be exposed via the openssl command line
 # and 'openssl md2' silently (!) gives the same result as md5

--- a/t/basic.t
+++ b/t/basic.t
@@ -1,6 +1,8 @@
 use SSL::Digest;
 use Test;
 
+use experimental :pack;
+
 plan 11;
 
 my Buf $random-bytes = Buf.new: (^128).roll: 10.pick;

--- a/t/binary.t
+++ b/t/binary.t
@@ -11,20 +11,31 @@ sub openssl($dgst, $buf = $test-buffer) {
     my $buffer-as-string = [~] map { sprintf("%02x", $_) }, $buf.list;
     qqx{
 	perl -e 'print pack "H*", "$buffer-as-string"' |
-	openssl dgst -$dgst -binary|
+	openssl dgst -$dgst -binary 2>/dev/null |
 	perl -e 'print unpack "H*", join "", <>;'
     }
 }
 
-is md4($test-buffer).unpack('H*'), openssl('md4'), 'MD4';
-is md5($test-buffer).unpack('H*'), openssl('md5'), 'MD5';
-is sha0($test-buffer).unpack('H*'), openssl('sha'), 'SHA-0';
-is sha1($test-buffer).unpack('H*'), openssl('sha1'), 'SHA-1';
-is sha224($test-buffer).unpack('H*'), openssl('sha224'), 'SHA-224';
-is sha256($test-buffer).unpack('H*'), openssl('sha256'), 'SHA-256';
-is sha384($test-buffer).unpack('H*'), openssl('sha384'), 'SHA-384';
-is sha512($test-buffer).unpack('H*'), openssl('sha512'), 'SHA-512';
-is rmd160($test-buffer).unpack('H*'), openssl('rmd160'), 'RIPEMD-160';
-is whirlpool($test-buffer).unpack('H*'), openssl('whirlpool'), 'WHIRLPOOL';
+sub test-digest(Buf $digest, Str $type, Str $desc ) {
+    my $expected = openssl($type);
+    if $expected {
+        is $digest.unpack('H*'), $expected, $desc;
+    }
+    else {
+        skip "unsupported digest type '$type'", 1
+    }
+}
+
+
+test-digest md4($test-buffer), 'md4', 'MD4';
+test-digest md5($test-buffer), 'md5', 'MD5';
+test-digest sha0($test-buffer), 'sha', 'SHA-0';
+test-digest sha1($test-buffer), 'sha1', 'SHA-1';
+test-digest sha224($test-buffer), 'sha224', 'SHA-224';
+test-digest sha256($test-buffer), 'sha256', 'SHA-256';
+test-digest sha384($test-buffer), 'sha384', 'SHA-384';
+test-digest sha512($test-buffer), 'sha512', 'SHA-512';
+test-digest rmd160($test-buffer), 'rmd160', 'RIPEMD-160';
+test-digest whirlpool($test-buffer), 'whirlpool', 'WHIRLPOOL';
 
 # vim: ft=perl6

--- a/t/binary.t
+++ b/t/binary.t
@@ -1,6 +1,8 @@
 use SSL::Digest;
 use Test;
 
+use experimental :pack;
+
 plan 10;
 
 my $test-buffer = Buf.new: (^256).roll: 100.pick;


### PR DESCRIPTION
It appears that some openssl binaries don't support all of the digest type despite the library doing so.
    
This just skips the test if there isn't an expected value to test against.
    
I've also included the earlier PR for 'experimental' for convenience
    
This should fix https://github.com/perl6/ecosystem-unbitrot/issues/518
